### PR TITLE
FHIR-43908 and FHIR-43914: cqlOptions

### DIFF
--- a/FHIR-uv-cql.xml
+++ b/FHIR-uv-cql.xml
@@ -6,10 +6,9 @@
 <artifactPageExtension value="-examples"/>
 <artifactPageExtension value="-mappings"/>
 <artifact id="Library/ANCCohort" key="Library-ANCCohort" name="ANC Cohort"/>
-<artifact id="CodeSystem/shareable-example" key="CodeSystem-shareable-example" name="ANCM Activity Codes"/>
-<artifact id="CodeSystem/publishable-example" key="CodeSystem-publishable-example" name="ANCM Concept Codes"/>
 <artifact id="StructureDefinition/cqf-cqlAccessLevel" key="StructureDefinition-cqf-cqlAccessLevel" name="CQL Access Level"/>
 <artifact id="OperationDefinition/cql-cql" key="OperationDefinition-cql-cql" name="CQL CQL"/>
+<artifact id="StructureDefinition/cql-cqlOptions" key="StructureDefinition-cql-cqlOptions" name="CQL CQL Options"/>
 <artifact id="StructureDefinition/cql-capabilitystatement" key="StructureDefinition-cql-capabilitystatement" name="CQL Capability Statement"/>
 <artifact id="StructureDefinition/cql-evaluationresult" key="StructureDefinition-cql-evaluationresult" name="CQL Evaluation Result"/>
 <artifact id="CapabilityStatement/cql-evaluation-service" key="CapabilityStatement-cql-evaluation-service" name="CQL Evaluation Service"/>
@@ -19,25 +18,28 @@
 <artifact id="OperationDefinition/cql-library-evaluate" key="OperationDefinition-cql-library-evaluate" name="CQL Library Evaluate"/>
 <artifact id="StructureDefinition/cql-modelinfo" key="StructureDefinition-cql-modelinfo" name="CQL Model Info"/>
 <artifact id="StructureDefinition/cql-module" key="StructureDefinition-cql-module" name="CQL Module"/>
+<artifact id="StructureDefinition/cql-options" key="StructureDefinition-cql-options" name="CQL Options"/>
 <artifact id="StructureDefinition/cql-structuredefinition" key="StructureDefinition-cql-structuredefinition" name="CQL StructureDefinition"/>
 <artifact id="StructureDefinition/cqf-cqlType" key="StructureDefinition-cqf-cqlType" name="CQL Type"/>
-<artifact id="ValueSet/anc-b5-de51" key="ValueSet-anc-b5-de51" name="Danger Signs - Central cyanosis Codes"/>
-<artifact id="ValueSet/anc-b5-de49" key="ValueSet-anc-b5-de49" name="Danger Signs - No danger signs Codes"/>
 <artifact id="StructureDefinition/cql-dangersigns-profile-example" key="StructureDefinition-cql-dangersigns-profile-example" name="Danger signs"/>
-<artifact id="ValueSet/anc-b5-de50" key="ValueSet-anc-b5-de50" name="Danger signs Codes"/>
-<artifact id="ValueSet/publishable-example" key="ValueSet-publishable-example" name="Danger signs Codes Grouper"/>
 <artifact id="StructureDefinition/elm-library" key="StructureDefinition-elm-library" name="ELM Library"/>
+<artifact id="CodeSystem/shareable-example" key="CodeSystem-shareable-example" name="Example ANCM Activity Codes"/>
+<artifact id="CodeSystem/publishable-example" key="CodeSystem-publishable-example" name="Example ANCM Concept Codes"/>
+<artifact id="ValueSet/anc-b5-de51" key="ValueSet-anc-b5-de51" name="Example Danger Signs - Central cyanosis Codes"/>
+<artifact id="ValueSet/anc-b5-de49" key="ValueSet-anc-b5-de49" name="Example Danger Signs - No danger signs Codes"/>
+<artifact id="ValueSet/anc-b5-de50" key="ValueSet-anc-b5-de50" name="Example Danger signs Codes"/>
+<artifact id="ValueSet/publishable-example" key="ValueSet-publishable-example" name="Example Danger signs Codes Grouper"/>
 <artifact id="Parameters/cql-evaluationresult-example" key="Parameters-cql-evaluationresult-example" name="Example Evaluation Result Parameters"/>
 <artifact id="Library/module-example" key="Library-module-example" name="Example Logic Library - Module Definition"/>
 <artifact id="Parameters/qicore-modelinfosettings" key="Parameters-qicore-modelinfosettings" name="Example ModelInfo Settings Parameters"/>
 <artifact id="Observation/negation-example" key="Observation-negation-example" name="Example Negation Observation"/>
 <artifact id="Patient/example" key="Patient-example" name="Example Patient"/>
+<artifact id="ValueSet/shareable-example" key="ValueSet-shareable-example" name="Example Specific health concern(s) Codes"/>
 <artifact id="Library/FHIRCommon" key="Library-FHIRCommon" name="FHIR Common"/>
 <artifact id="Library/ELMExample" key="Library-ELMExample" name="FHIR Common (Compiled CQL Example)"/>
 <artifact id="Library/CQLExample" key="Library-CQLExample" name="FHIR Common (Source CQL Example)"/>
 <artifact id="CapabilityStatement/cql-evaluation-service-example" key="CapabilityStatement-cql-evaluation-service-example" name="Library Evaluation Service Capability Statement Example"/>
 <artifact id="StructureDefinition/cql-specifichealthconcerns-profile-example" key="StructureDefinition-cql-specifichealthconcerns-profile-example" name="Specific health concern(s)"/>
-<artifact id="ValueSet/shareable-example" key="ValueSet-shareable-example" name="Specific health concern(s) Codes"/>
 <artifact id="Library/modelinfo-example" key="Library-modelinfo-example" name="USCore Model Definition"/>
 <page key="NA" name="(NA)"/>
 <page key="many" name="(many)"/>

--- a/input/profiles/StructureDefinition-cql-cqlOptions.json
+++ b/input/profiles/StructureDefinition-cql-cqlOptions.json
@@ -1,0 +1,77 @@
+{
+    "resourceType" : "StructureDefinition",
+    "id" : "cql-cqlOptions",
+    "extension" : [{
+      "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+      "valueCode" : "cds"
+    },
+    {
+      "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+      "valueInteger" : 1
+    },
+    {
+      "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+      "valueCode" : "draft"
+    }],
+    "url" : "http://hl7.org/fhir/uv/cql/StructureDefinition/cql-cqlOptions",
+    "name" : "CQLCQLOptions",
+    "title" : "CQL CQL Options",
+    "status" : "draft",
+    "experimental" : true,
+    "date" : "2024-03-26",
+    "publisher" : "Clinical Decision Support WG",
+    "contact" : [{
+      "telecom" : [{
+        "system" : "url",
+        "value" : "http://www.hl7.org/Special/committees/dss"
+      }]
+    }],    
+    "description" : "Specifies a parameters (contained) resource that identifies the options for the CQL-to-ELM translator associated with the CQL content.",
+    "jurisdiction" : [{
+      "coding" : [{
+        "system" : "http://unstats.un.org/unsd/methods/m49/m49.htm",
+        "code" : "001"
+      }]
+    }],
+    "purpose" : "Because CQL-to-ELM translator options may impact the translation of CQL source libraries, authoring, distribution, and evaluation environments need to know what options the CQL was built with.",
+    "fhirVersion" : "4.0.1",
+    "mapping" : [{
+      "identity" : "rim",
+      "uri" : "http://hl7.org/v3",
+      "name" : "RIM Mapping"
+    }],
+    "kind" : "complex-type",
+    "abstract" : false,
+    "context" : [{
+      "type" : "element",
+      "expression" : "Library"
+    }],
+    "type" : "Extension",
+    "baseDefinition" : "http://hl7.org/fhir/StructureDefinition/cqf-cqlOptions",
+    "derivation" : "constraint",
+    "differential" : {
+      "element" : [{
+        "id" : "Extension",
+        "path" : "Extension",
+        "short" : "What options",
+        "definition" : "Specifies a parameters (contained) resource that identifies the options for the CQL-to-ELM translator associated with the CQL content.",
+        "comment" : "When this extension is used with a specific CQL library, it indicates the options that are to be used to translate the CQL to ELM. ELM Libraries carry the options they were translated with, so this does not need to be specified. If the options are not specified, the translation options identified [here](https://build.fhir.org/ig/HL7/crmi-ig/using-cql.html#translation-to-elm) are used.",
+        "min" : 0,
+        "max" : "1"
+      },
+      {
+        "id" : "Extension.url",
+        "path" : "Extension.url",
+        "fixedUri" : "http://hl7.org/fhir/uv/cql/StructureDefinition/cql-cqlOptions"
+      },
+      {
+        "id" : "Extension.value[x]",
+        "path" : "Extension.value[x]",
+        "min" : 1,
+        "type" : [{
+          "code" : "Reference",
+          "targetProfile" : ["http://hl7.org/fhir/uv/cql/StructureDefinition/cql-options"]
+        }]
+      }]
+    }
+  }

--- a/input/profiles/StructureDefinition-cql-library.json
+++ b/input/profiles/StructureDefinition-cql-library.json
@@ -75,7 +75,7 @@
           {
             "code": "Extension",
             "profile": [
-              "http://hl7.org/fhir/StructureDefinition/cqf-cqlOptions"
+              "http://hl7.org/fhir/uv/cql/StructureDefinition/cql-cqlOptions"
             ]
           }
         ],

--- a/input/profiles/StructureDefinition-cql-options.json
+++ b/input/profiles/StructureDefinition-cql-options.json
@@ -1,0 +1,464 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "cql-options",
+  "extension" : [{
+    "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm",
+    "valueInteger" : 1
+  },
+  {
+    "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-wg",
+    "valueCode" : "cds"
+  },
+  {
+    "url" : "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+    "valueCode" : "trial-use"
+  }],
+  "url": "http://hl7.org/fhir/uv/cql/StructureDefinition/cql-options",
+  "name": "CQLOptions",
+  "title": "CQL Options",
+  "status": "active",
+  "experimental": false,
+  "publisher": "Clinical Decision Support WG",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/dss/index.cfm"
+        }
+      ]
+    }
+  ],
+  "description": "CQL-to-ELM translator options that were used to build the CQL.",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "v2",
+      "uri": "http://hl7.org/v2",
+      "name": "HL7 v2 Mapping"
+    },
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    }
+  ],
+  "kind": "resource",
+  "abstract": false,
+  "type": "Parameters",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Parameters",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Parameters.parameter",
+        "path": "Parameters.parameter",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        }
+      },
+      {
+        "id": "Parameters.parameter:enableAnnotations",
+        "path": "Parameters.parameter",
+        "sliceName": "enableAnnotations",
+        "short": "This instructs the translator to include the source CQL as an annotation within the ELM.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:enableAnnotations.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "enableAnnotations"
+      },
+      {
+        "id": "Parameters.parameter:enableAnnotations.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },    
+      {
+        "id": "Parameters.parameter:enableLocators",
+        "path": "Parameters.parameter",
+        "sliceName": "enableLocators",
+        "short": "This instructs the translator to include line number and character information for each ELM node.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:enableLocators.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "enableLocators"
+      },
+      {
+        "id": "Parameters.parameter:enableLocators.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },
+      {
+        "id": "Parameters.parameter:disableListDemotion",
+        "path": "Parameters.parameter",
+        "sliceName": "disableListDemotion",
+        "short": "This instructs the translator to disallow demotion of list-valued expressions to singletons. The list demotion feature of CQL is used to enable functionality related to use with FHIRPath.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:disableListDemotion.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "disableListDemotion"
+      },
+      {
+        "id": "Parameters.parameter:disableListDemotion.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },
+      {
+        "id": "Parameters.parameter:disableListPromotion",
+        "path": "Parameters.parameter",
+        "sliceName": "disableListPromotion",
+        "short": "This instructs the translator to disallow promotion of singletons to list-valued expressions. The list promotion feature of CQL is used to enable functionality related to use with FHIRPath.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:disableListPromotion.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "disableListPromotion"
+      },
+      {
+        "id": "Parameters.parameter:disableListPromotion.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },
+      {
+        "id": "Parameters.parameter:disableMethodInvocation",
+        "path": "Parameters.parameter",
+        "sliceName": "disableMethodInvocation",
+        "short": "This instructs the translator to disallow method-style invocation. The method-style invocation feature of CQL is used to enable functionality related to use with FHIRPath.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:disableMethodInvocation.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "disableMethodInvocation"
+      },
+      {
+        "id": "Parameters.parameter:disableMethodInvocation.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },
+      {
+        "id": "Parameters.parameter:enableDateRangeOptimization",
+        "path": "Parameters.parameter",
+        "sliceName": "enableDateRangeOptimization",
+        "short": "This instructs the translator to optimize date range filters by moving them inside retrieve expressions.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:enableDateRangeOptimization.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "enableDateRangeOptimization"
+      },
+      {
+        "id": "Parameters.parameter:enableDateRangeOptimization.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },
+      {
+        "id": "Parameters.parameter:enableResultTypes",
+        "path": "Parameters.parameter",
+        "sliceName": "enableResultTypes",
+        "short": "This instructs the translator to include inferred result types in the output ELM.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:enableResultTypes.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "enableResultTypes"
+      },
+      {
+        "id": "Parameters.parameter:enableResultTypes.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },
+      {
+        "id": "Parameters.parameter:enableDetailedErrors",
+        "path": "Parameters.parameter",
+        "sliceName": "enableDetailedErrors",
+        "short": "This instructs the translator to include detailed error information. By default, the translator only reports root-cause errors.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:enableDetailedErrors.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "enableDetailedErrors"
+      },
+      {
+        "id": "Parameters.parameter:enableDetailedErrors.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },
+      {
+        "id": "Parameters.parameter:disableListTraversal",
+        "path": "Parameters.parameter",
+        "sliceName": "disableListTraversal",
+        "short": "This instructs the translator to disallow traversal of list-valued expressions. With knowledge artifacts, disabling this feature would prevent a useful capability.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:disableListTraversal.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "disableListTraversal"
+      },
+      {
+        "id": "Parameters.parameter:disableListTraversal.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },
+      {
+        "id": "Parameters.parameter:signatureLevel",
+        "path": "Parameters.parameter",
+        "sliceName": "signatureLevel",
+        "short": "This setting controls whether the signature element of a FunctionRef will be populated.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:signatureLevel.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "signatureLevel"
+      },
+      {
+        "id": "Parameters.parameter:signatureLevel.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "CodeableConcept"
+          }        
+        ],
+        "binding" : {
+          "strength" : "extensible",
+          "valueSet" : "http://hl7.org/fhir/us/using-cql/ValueSet/signature-level"
+        }        
+      },
+      {
+        "id": "Parameters.parameter:translatorVersion",
+        "path": "Parameters.parameter",
+        "sliceName": "translatorVersion",
+        "short": "Version of the CQL-to-ELM translator.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:translatorVersion.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "translatorVersion"
+      },
+      {
+        "id": "Parameters.parameter:translatorVersion.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },        
+      {
+        "id": "Parameters.parameter:format",
+        "path": "Parameters.parameter",
+        "sliceName": "format",
+        "short": "Format in JSON or XML.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:format.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "format"
+      },
+      {
+        "id": "Parameters.parameter:format.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },  
+      {
+        "id": "Parameters.parameter:compatibilityLevel",
+        "path": "Parameters.parameter",
+        "sliceName": "compatibilityLevel",
+        "short": "This setting indicates the compatibility level.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:compatibilityLevel.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "compatibilityLevel"
+      },
+      {
+        "id": "Parameters.parameter:compatibilityLevel.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      {
+        "id": "Parameters.parameter:enableCqlOnly",
+        "path": "Parameters.parameter",
+        "sliceName": "enableCqlOnly",
+        "short": "Enable CQL only.",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:enableCqlOnly.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "enableCqlOnly"
+      },
+      {
+        "id": "Parameters.parameter:enableCqlOnly.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },
+      {
+        "id": "Parameters.parameter:errorLevel",
+        "path": "Parameters.parameter",
+        "sliceName": "errorLevel",
+        "short": "Error level",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:errorLevel.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "errorLevel"
+      },
+      {
+        "id": "Parameters.parameter:errorLevel.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "string"
+          }
+        ]
+      },
+      {
+        "id": "Parameters.parameter:validateUnits",
+        "path": "Parameters.parameter",
+        "sliceName": "validateUnits",
+        "short": "Validate units",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:validateUnits.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "validateUnits"
+      },
+      {
+        "id": "Parameters.parameter:validateUnits.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      },  
+      {
+        "id": "Parameters.parameter:verifyOnly",
+        "path": "Parameters.parameter",
+        "sliceName": "verifyOnly",
+        "short": "Verify only",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Parameters.parameter:verifyOnly.name",
+        "path": "Parameters.parameter.name",
+        "fixedString": "verifyOnly"
+      },
+      {
+        "id": "Parameters.parameter:verifyOnly.value[x]",
+        "path": "Parameters.parameter.value[x]",
+        "min": 1,
+        "type": [
+          {
+            "code": "boolean"
+          }
+        ]
+      }                             
+    ]
+  }
+}

--- a/input/profiles/StructureDefinition-elm-library.json
+++ b/input/profiles/StructureDefinition-elm-library.json
@@ -83,7 +83,7 @@
           {
             "code": "Extension",
             "profile": [
-              "http://hl7.org/fhir/StructureDefinition/cqf-cqlOptions"
+              "http://hl7.org/fhir/uv/cql/StructureDefinition/cql-cqlOptions"
             ]
           }
         ],


### PR DESCRIPTION
https://jira.hl7.org/browse/FHIR-43908
https://jira.hl7.org/browse/FHIR-43914

Changes applied so far included in this pull request:
1. Created new Parameters profile CQL Options (cql-options) with named slices for all parameters that are listed in the table under section 2.17 (https://build.fhir.org/ig/HL7/cql-ig/using-cql.html#translation-to-elm) and additional parameters seen in examples in 2.17.1. 
2. Created an cql-cqlOptions extension that is derived from the cqf-cqlOptions from the Extension Pack and referenced the new CQL Options profile. 
3. Updated CQLLibrary and ELMLibrary profiles to use the cql-cqlOptions extension instead of the cqf-cqlOptions extension from the Extension Pack

Not yet done:
1. For the CQL Options profile, need to create invariants to constrain the parameters that have an enumerated list as value
- SingatureLevel  (value: All, Overloads)
- Format  (value: JSON, XML)
- ErrorLevel (value: Info .... and maybe other?)

2. A few of the parameters in CQL Options need better definitions (I put in some placeholder definitions):
- translatorVersion
- format
- compatibilityLevel
- enableCqlOnly
- errorLevel
- validateUnits
- verifyOnly
3. Not yet added the new profiles and new extensions to the Profiles and Extensions markdown pages
4. Not yet added the two trackers to the change log